### PR TITLE
Only send claims in authorize request if they are present

### DIFF
--- a/src/GovUk.OneLogin.AspNetCore/OneLoginOptions.cs
+++ b/src/GovUk.OneLogin.AspNetCore/OneLoginOptions.cs
@@ -144,7 +144,11 @@ public class OneLoginOptions
         ValidateOptionNotNull(VectorsOfTrust);
 
         context.ProtocolMessage.Parameters.Add("vtr", VectorsOfTrust);
-        context.ProtocolMessage.Parameters.Add("claims", GetClaimsRequest());
+
+        if (Claims.Count > 0)
+        {
+            context.ProtocolMessage.Parameters.Add("claims", GetClaimsRequest());
+        }
 
         if (UiLocales is not null)
         {


### PR DESCRIPTION
This will currently send an empty claims object, which One Login does not parse correctly. One Login will be fixing this, but best to fix at both ends.