### PR TITLE
Rename VectorsOfTrust to VectorOfTrust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+The `VectorsOfTrust` property on `OneLoginOptions` has been renamed to `VectorOfTrust`.
+
+
 ## 0.2.1
 
 Fixes population of underlying `OpenIdConnectOptions`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ builder.Services.AddAuthentication(defaultScheme: OneLoginDefaults.Authenticatio
 
         // Configure vectors of trust.
         // See the One Login docs for the various options to use here.
-        options.VectorsOfTrust = @"[""Cl""]";
+        options.VectorOfTrust = @"[""Cl""]";
 
         // Override the cookie name prefixes (optional)
         options.CorrelationCookie.Name = "my-app-onelogin-correlation.";
@@ -55,7 +55,7 @@ If you're using One Login for identity verification you will need some additiona
 ```cs
 .AddOneLogin(options =>
 {
-    options.VectorsOfTrust = @"[""Cl.Cm.P2""]";
+    options.VectorOfTrust = @"[""Cl.Cm.P2""]";
 
     // Add the additional claims to authorization requests.
     options.Claims.Add(OneLoginClaimTypes.CoreIdentity);

--- a/src/GovUk.OneLogin.AspNetCore/OneLoginOptions.cs
+++ b/src/GovUk.OneLogin.AspNetCore/OneLoginOptions.cs
@@ -44,7 +44,7 @@ public class OneLoginOptions
         OpenIdConnectOptions.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
 
         ClientAssertionJwtExpiry = TimeSpan.FromMinutes(5);  // One Login docs recommend 5 minutes
-        VectorsOfTrust = @"[""Cl.Cm""]";
+        VectorOfTrust = @"[""Cl.Cm""]";
 
         Claims = new HashSet<string>();
 
@@ -98,7 +98,7 @@ public class OneLoginOptions
     /// Gets or sets the 'vtr'.
     /// </summary>
     [DisallowNull]
-    public string? VectorsOfTrust { get; set; }
+    public string? VectorOfTrust { get; set; }
 
     /// <summary>
     /// Gets the list of claims to request.
@@ -161,7 +161,7 @@ public class OneLoginOptions
         ValidateOptionNotNull(ClientId);
         ValidateOptionNotNull(ClientAuthenticationCredentials);
         ValidateOptionNotNull(ClientAssertionJwtAudience);
-        ValidateOptionNotNull(VectorsOfTrust);
+        ValidateOptionNotNull(VectorOfTrust);
         ValidateOptionNotNull(SignInScheme);
 
         if (IncludesCoreIdentityClaim)
@@ -197,9 +197,9 @@ public class OneLoginOptions
 
     internal Task OnRedirectToIdentityProvider(RedirectContext context)
     {
-        ValidateOptionNotNull(VectorsOfTrust);
+        ValidateOptionNotNull(VectorOfTrust);
 
-        context.ProtocolMessage.Parameters.Add("vtr", VectorsOfTrust);
+        context.ProtocolMessage.Parameters.Add("vtr", VectorOfTrust);
 
         if (Claims.Count > 0)
         {


### PR DESCRIPTION
The singular form seems to be used consistently everywhere else.