### PR TITLE
Expose OpenIdConnectEvents on OneLoginOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Adds `NationalInsuranceNumber` member to `OneLoginClaimTypes`.
 
+Adds `OpenIdConnectEvents` property to `OneLoginOptions` to allow more control over the OIDC interactions with One Login.
+
 ## 0.3.0
 
 ### New features


### PR DESCRIPTION
Currently we hide `OpenIdConnectEvents` in our implementation but it's useful for consumers to be able to add their own customizations.