### PR TITLE
Get core identity signing key from DID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Adds support for JWT-secured OAuth 2.0 authorisation request (JAR) and enables i
 
 Replaces the `string` `VectorOfTrust` property on `OneLoginOptions` with an `ICollection<string>` property `VectorOfTrusts`.
 
+Removes the `MetadataAddress`, `ClientAssertionJwtAudience`, `CoreIdentityClaimIssuer` and `CoreIdentityClaimIssuerSigningKey` options and replaces them with `Environment`.
+The `CoreIdentityClaimIssuerSigningKey` is now sourced from One Login's DID and is refreshed automatically.
+
 ## 0.3.1
 
 Adds `NationalInsuranceNumber` member to `OneLoginClaimTypes`.

--- a/src/GovUk.OneLogin.AspNetCore/CoreIdentityHelper.cs
+++ b/src/GovUk.OneLogin.AspNetCore/CoreIdentityHelper.cs
@@ -1,0 +1,179 @@
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+
+namespace GovUk.OneLogin.AspNetCore;
+
+internal sealed class CoreIdentityHelper : IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly OneLoginOptions _options;
+    private readonly ILogger<CoreIdentityHelper> _logger;
+    private readonly JwtSecurityTokenHandler _tokenHandler;
+    private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);  // The lock that guards against multiple DID requests happening at once.
+    private Did? _did;
+    private DateTimeOffset? _didExpires;
+
+    public CoreIdentityHelper(HttpClient httpClient, OneLoginOptions options, ILogger<CoreIdentityHelper> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClient = httpClient;
+        _options = options;
+        _logger = logger;
+
+        _tokenHandler = new JwtSecurityTokenHandler
+        {
+            MapInboundClaims = false
+        };
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+
+    internal ClaimsPrincipal ValidateCoreIdentity(string coreIdentityJwt)
+    {
+        if (_did is null)
+        {
+            throw new InvalidOperationException("DID has not been fetched.");
+        }
+
+        OneLoginOptions.ValidateOptionNotNull(_options.Environment);
+        var coreIdentityClaimIssuer = OneLoginEnvironments.GetCoreIdentityClaimIssuer(_options.Environment);
+
+        var tokenValidationParameters = new TokenValidationParameters()
+        {
+            ValidIssuer = coreIdentityClaimIssuer,
+            ValidateAudience = false,
+            NameClaimType = "sub",
+            IssuerSigningKeyResolver = (string token, SecurityToken securityToken, string kid, TokenValidationParameters validationParameters) =>
+            {
+                var controllerId = kid.Split('#')[0];
+                if (controllerId != _did.Id)
+                {
+                    return Enumerable.Empty<SecurityKey>();
+                }
+
+                var assertionMethods = _did.JwkAssertionMethods;
+                return assertionMethods.Where(am => am.Id == kid).Select(am => am.Key);
+            }
+        };
+
+        var coreIdentityPrincipal = _tokenHandler.ValidateToken(coreIdentityJwt, tokenValidationParameters, out var securityKey);
+
+        return coreIdentityPrincipal;
+    }
+
+    internal async Task EnsureDidDocument()
+    {
+        if (_did is null)
+        {
+            await LoadDid();
+        }
+        else if (_didExpires is DateTimeOffset expires && expires < DateTimeOffset.UtcNow)
+        {
+            // Docs say that a cached document should be used if refreshing the document fails
+            // so we should not bubble up any exceptions here.
+
+            try
+            {
+                await LoadDid();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to refresh DID document.");
+            }
+        }
+
+        Debug.Assert(_did is not null);
+    }
+
+    private async Task LoadDid()
+    {
+        OneLoginOptions.ValidateOptionNotNull(_options.Environment);
+        var endpoint = OneLoginEnvironments.GetDidEndpoint(_options.Environment);
+
+        await _lock.WaitAsync();
+        try
+        {
+            var response = await _httpClient.GetAsync(endpoint);
+            response.EnsureSuccessStatusCode();
+
+            DateTimeOffset? didDocumentExpires = null;
+            if (response.Headers.CacheControl?.MaxAge is TimeSpan maxAge)
+            {
+                didDocumentExpires = DateTimeOffset.UtcNow.Add(maxAge);
+            }
+
+            using var document = JsonSerializer.Deserialize<JsonDocument>(await response.Content.ReadAsStringAsync())!;
+
+            if (!document.RootElement.TryGetProperty("id", out var docIdElement) || docIdElement.ValueKind != JsonValueKind.String)
+            {
+                throw new Exception("DID does not contain an 'id' string property.");
+            }
+            if (!document.RootElement.TryGetProperty("assertionMethod", out var assertionMethodsElement) || assertionMethodsElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new Exception("DID does not contain an 'assertionMethod' array property.");
+            }
+
+            var docId = docIdElement.GetString()!;
+
+            var assertionMethods = new List<JwkAssertionMethod>();
+
+            foreach (var assertionMethod in assertionMethodsElement.EnumerateArray())
+            {
+                var type = assertionMethod.GetProperty("type").GetString();
+                if (type != "JsonWebKey")
+                {
+                    continue;
+                }
+
+                if (assertionMethod.TryGetProperty("id", out var idElement) && idElement.ValueKind == JsonValueKind.String &&
+                    assertionMethod.TryGetProperty("controller", out var controllerElement) && controllerElement.ValueKind == JsonValueKind.String &&
+                    assertionMethod.TryGetProperty("publicKeyJwk", out var publicKeyJwkElement) && publicKeyJwkElement.ValueKind == JsonValueKind.Object)
+                {
+                    var key = JsonWebKey.Create(publicKeyJwkElement.ToString());
+
+                    assertionMethods.Add(new JwkAssertionMethod(idElement.GetString()!, controllerElement.GetString()!, key));
+                }
+            }
+
+            _did = new Did(docId, assertionMethods.ToArray());
+            _didExpires = didDocumentExpires;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private class Did
+    {
+        public Did(string id, JwkAssertionMethod[] jwkAssertionMethods)
+        {
+            Id = id;
+            JwkAssertionMethods = jwkAssertionMethods;
+        }
+
+        public string Id { get; }
+        public JwkAssertionMethod[] JwkAssertionMethods { get; }
+    }
+
+    private class JwkAssertionMethod
+    {
+        public JwkAssertionMethod(string id, string controller, JsonWebKey key)
+        {
+            Id = id;
+            Controller = controller;
+            Key = key;
+        }
+
+        public string Id { get; }
+        public string Controller { get; }
+        public JsonWebKey Key { get; }
+    }
+}

--- a/src/GovUk.OneLogin.AspNetCore/GovUk.OneLogin.AspNetCore.csproj
+++ b/src/GovUk.OneLogin.AspNetCore/GovUk.OneLogin.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <Description>ASP.NET Core integration for GOV.UK One Login</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>0.4</MinVerMinimumMajorMinor>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/GovUk.OneLogin.AspNetCore/OneLoginEnvironments.cs
+++ b/src/GovUk.OneLogin.AspNetCore/OneLoginEnvironments.cs
@@ -1,0 +1,91 @@
+using System.Reflection.Metadata;
+
+namespace GovUk.OneLogin.AspNetCore;
+
+/// <summary>
+/// Contains the set of known One Login environments.
+/// </summary>
+public static class OneLoginEnvironments
+{
+    private static IReadOnlyDictionary<string, EnvironmentInfo> _environments = new[]
+    {
+        new EnvironmentInfo(
+            Integration,
+            MetadataAddress: "https://oidc.integration.account.gov.uk/.well-known/openid-configuration",
+            ClientAssertionJwtAudience: "https://oidc.integration.account.gov.uk/token",
+            CoreIdentityClaimsIssuer: "https://identity.integration.account.gov.uk/",
+            DidEndpoint: "https://identity.integration.account.gov.uk/.well-known/did.json"),
+        new EnvironmentInfo(
+            Production,
+            MetadataAddress: "https://oidc.account.gov.uk/.well-known/openid-configuration",
+            ClientAssertionJwtAudience: "https://oidc.account.gov.uk/token",
+            CoreIdentityClaimsIssuer: "https://identity.account.gov.uk/",
+            DidEndpoint: "https://identity.account.gov.uk/.well-known/did.json")
+    }
+    .ToDictionary(e => e.Name, e => e);
+
+    /// <summary>
+    /// The integration environment.
+    /// </summary>
+    public const string Integration = "Integration";
+
+    /// <summary>
+    /// The production environment.
+    /// </summary>
+    public const string Production = "Production";
+
+    internal static string GetMetadataAddress(string environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        if (!_environments.TryGetValue(environment, out var info))
+        {
+            throw new ArgumentException($"Unknown environment: '{environment}'.", nameof(environment));
+        }
+
+        return info.MetadataAddress;
+    }
+
+    internal static string GetClientAssertionJwtAudience(string environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        return environment switch
+        {
+            Integration => "https://oidc.integration.account.gov.uk/token",
+            Production => "https://oidc.account.gov.uk/token",
+            _ => throw new ArgumentException($"Unknown environment: '{environment}'.", nameof(environment))
+        };
+    }
+
+    internal static string GetCoreIdentityClaimIssuer(string environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        return environment switch
+        {
+            Integration => "https://identity.integration.account.gov.uk/",
+            Production => "https://identity.account.gov.uk/",
+            _ => throw new ArgumentException($"Unknown environment: '{environment}'.", nameof(environment))
+        };
+    }
+
+    internal static string GetDidEndpoint(string environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        return environment switch
+        {
+            Integration => "https://identity.integration.account.gov.uk/.well-known/did.json",
+            Production => "https://identity.account.gov.uk/.well-known/did.json",
+            _ => throw new ArgumentException($"Unknown environment: '{environment}'.", nameof(environment))
+        };
+    }
+
+    private record EnvironmentInfo(
+        string Name,
+        string MetadataAddress,
+        string ClientAssertionJwtAudience,
+        string CoreIdentityClaimsIssuer,
+        string DidEndpoint);
+}

--- a/src/GovUk.OneLogin.AspNetCore/OneLoginExtensions.cs
+++ b/src/GovUk.OneLogin.AspNetCore/OneLoginExtensions.cs
@@ -80,6 +80,7 @@ public static partial class OneLoginExtensions
         });
 
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OneLoginOptions>, OneLoginPostConfigureOptions>());
+        builder.Services.AddHttpClient();
 
         return builder;
     }

--- a/src/GovUk.OneLogin.AspNetCore/OneLoginPostConfigureOptions.cs
+++ b/src/GovUk.OneLogin.AspNetCore/OneLoginPostConfigureOptions.cs
@@ -25,6 +25,8 @@ public class OneLoginPostConfigureOptions : IPostConfigureOptions<OneLoginOption
     {
         ArgumentNullException.ThrowIfNull(name);
 
+        options.OpenIdConnectOptions.MetadataAddress = OneLoginEnvironments.GetMetadataAddress(options.Environment!);
+
         if (options.IncludesCoreIdentityClaim)
         {
             options.OpenIdConnectOptions.ClaimActions.Add(new ProcessCoreIdentityJwtClaimAction(options));


### PR DESCRIPTION
Also removes the `MetadataAddress`, `ClientAssertionJwtAudience`, `CoreIdentityClaimIssuer` and `CoreIdentityClaimIssuerSigningKey` options and uses a single `Environment` option in their place.

Some additional context: https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#validate-the-core-identity-claim-jwt-using-a-public-key