### PR TITLE
Shorten the authentication property key used for tracking VTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Adds `UsePkce` option.
 
+Shortens the property name used to track VTR in `AuthenticationProperties`.
+
 ## 0.4.0
 
 Adds support for JWT-secured OAuth 2.0 authorisation request (JAR) and enables it by default.

--- a/src/GovUk.OneLogin.AspNetCore/AuthenticationPropertiesExtensions.cs
+++ b/src/GovUk.OneLogin.AspNetCore/AuthenticationPropertiesExtensions.cs
@@ -8,7 +8,7 @@ namespace GovUk.OneLogin.AspNetCore;
 /// </summary>
 public static class AuthenticationPropertiesExtensions
 {
-    private const string VectorsOfTrustKey = "GovUk.OneLogin.AspNetCore.VectorsOfTrust";
+    private const string VectorsOfTrustKey = ".ol.vtr";
 
     /// <summary>
     /// Gets the vectors of trust to use when authenticating using GOV.UK One Login.


### PR DESCRIPTION
Helps to keep the OAuth `state` property a little smaller.